### PR TITLE
Allow downloading of importing templates

### DIFF
--- a/nginx/akaunting
+++ b/nginx/akaunting
@@ -6,7 +6,7 @@ server {
     root /var/www/akaunting/root;
 
     # Static files
-    location ~ ^/(public|modules|vendor)/(.*\.(ico|gif|jpg|jpeg|png|js|css|less|sass|font|woff|woff2|eot|ttf|svg))$ {
+    location ~ ^/(public|modules|vendor)/(.*\.(ico|gif|jpg|jpeg|png|js|css|less|sass|font|woff|woff2|eot|ttf|svg|csv|xls|xlsx))$ {
         alias /var/www/akaunting/$1/$2;
     }
 


### PR DESCRIPTION
To import data into invoices issues etc a certain format needs to befollowed, akkaunting provides examples in the form of .xlsx and .csv file under the public directory. Unfortunately they are blocked