### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,6 +133,9 @@ wait_for_php_fpm
 # MySQL          #
 ##################
 
+# force set to be +e so error do NEVER terminate the script and errorhandling can be done here
+set +e
+
 # Check if password was changed
 echo "\
 [client]


### PR DESCRIPTION
after a restart of the container i would face lockout of the container
akaunting_1  | Waiting for php-fpm
akaunting_1  | == MYSQL_DEFAULT_PASSWORD
akaunting_1  | ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)


set -e seemed to be active in my setup, causing the script to terminate early
termination was not desired as after a restart failing access to mysql the entrypointscript was
supposed to continue based on the error status.